### PR TITLE
copy noise scaling pars from scaleNoise to SCfind

### DIFF
--- a/SoFiA_default_input.txt
+++ b/SoFiA_default_input.txt
@@ -84,7 +84,7 @@ scaleNoise.windowSpectral       =       15
 scaleNoise.gridSpatial          =       0
 scaleNoise.gridSpectral         =       0
 scaleNoise.interpolation        =       none
-scaleNoise.scaleEachSCkernel    =       false
+scaleNoise.perSCkernel          =       false
 
 
 # Filter artefacts

--- a/SoFiA_default_input.txt
+++ b/SoFiA_default_input.txt
@@ -84,6 +84,7 @@ scaleNoise.windowSpectral       =       15
 scaleNoise.gridSpatial          =       0
 scaleNoise.gridSpectral         =       0
 scaleNoise.interpolation        =       none
+scaleNoise.scaleEachSCkernel    =       false
 
 
 # Filter artefacts
@@ -112,19 +113,6 @@ SCfind.rmsMode                  =       negative
 SCfind.fluxRange                =       all
 SCfind.kernels                  =       [[0, 0, 0, 'b'], [0, 0, 3, 'b'], [0, 0, 7, 'b'], [0, 0, 15, 'b'], [3, 3, 0, 'b'], [3, 3, 3, 'b'], [3, 3, 7, 'b'], [3, 3, 15, 'b'], [6, 6, 0, 'b'], [6, 6, 3, 'b'], [6, 6, 7, 'b'], [6, 6, 15, 'b']]
 SCfind.kernelUnit               =       pixel
-SCfind.kernelNoiseScale         =       false
-SCfind.method                   =       global
-SCfind.scaleX                   =       false
-SCfind.scaleY                   =       false
-SCfind.scaleZ                   =       true
-SCfind.edgeX                    =       0
-SCfind.edgeY                    =       0
-SCfind.edgeZ                    =       0
-SCfind.windowSpatial            =       25
-SCfind.windowSpectral           =       15
-SCfind.gridSpatial              =       0
-SCfind.gridSpectral             =       0
-SCfind.interpolation            =       none
 SCfind.verbose                  =       true
 
 

--- a/sofia/pyfind.py
+++ b/sofia/pyfind.py
@@ -13,7 +13,7 @@ from sofia.sigma_cube import sigma_scale
 # FUNCTION: Implementation of the S+C finder
 # ==========================================
 
-def SCfinder_mem(cube, mask, header, t0, kernels=[[0, 0, 0, "b"],], threshold=3.5, sizeFilter=0, maskScaleXY=2.0, maskScaleZ=2.0, kernelUnit="pixel", edgeMode="constant", rmsMode="negative", fluxRange="all", verbose=0, kernelNoiseScale=False, scaleX=False, scaleY=False, scaleZ=True, edgeX=0, edgeY=0, edgeZ=0, method="1d2d", windowSpatial=20, windowSpectral=20, gridSpatial=0, gridSpectral=0, interpolation="none"):
+def SCfinder_mem(cube, mask, header, t0, kernels=[[0, 0, 0, "b"],], threshold=3.5, sizeFilter=0, maskScaleXY=2.0, maskScaleZ=2.0, kernelUnit="pixel", edgeMode="constant", rmsMode="negative", fluxRange="all", verbose=0, scaleEachSCkernel=False, scaleX=False, scaleY=False, scaleZ=True, edgeX=0, edgeY=0, edgeZ=0, method="1d2d", windowSpatial=20, windowSpectral=20, gridSpatial=0, gridSpectral=0, interpolation="none"):
 	# Define a few constants
 	FWHM_CONST    = 2.0 * math.sqrt(2.0 * math.log(2.0))   # Conversion between sigma and FWHM of Gaussian function
 	MAX_PIX_CONST = 1.0e+6                                 # Maximum number of pixels for noise calculation; sampling is set accordingly
@@ -67,7 +67,7 @@ def SCfinder_mem(cube, mask, header, t0, kernels=[[0, 0, 0, "b"],], threshold=3.
 			cube_smooth[np.isnan(cube)] = np.nan
 		
 		# Per-kernel noise normalisation (Time consuming!)
-		if kernelNoiseScale:
+		if scaleEachSCkernel:
 			cube_smooth, noise_smooth = sigma_scale(cube_smooth, scaleX=scaleX, scaleY=scaleY, scaleZ=scaleZ, edgeX=edgeX, edgeY=edgeY, edgeZ=edgeZ, statistic=rmsMode, fluxRange=fluxRange, method=method, windowSpatial=windowSpatial, windowSpectral=windowSpectral, gridSpatial=gridSpatial, gridSpectral=gridSpectral, interpolation=interpolation)
 
 		# Calculate the RMS of the smoothed (possibly normalised) cube

--- a/sofia/pyfind.py
+++ b/sofia/pyfind.py
@@ -13,7 +13,7 @@ from sofia.sigma_cube import sigma_scale
 # FUNCTION: Implementation of the S+C finder
 # ==========================================
 
-def SCfinder_mem(cube, mask, header, t0, kernels=[[0, 0, 0, "b"],], threshold=3.5, sizeFilter=0, maskScaleXY=2.0, maskScaleZ=2.0, kernelUnit="pixel", edgeMode="constant", rmsMode="negative", fluxRange="all", verbose=0, scaleEachSCkernel=False, scaleX=False, scaleY=False, scaleZ=True, edgeX=0, edgeY=0, edgeZ=0, method="1d2d", windowSpatial=20, windowSpectral=20, gridSpatial=0, gridSpectral=0, interpolation="none"):
+def SCfinder_mem(cube, mask, header, t0, kernels=[[0, 0, 0, "b"],], threshold=3.5, sizeFilter=0, maskScaleXY=2.0, maskScaleZ=2.0, kernelUnit="pixel", edgeMode="constant", rmsMode="negative", fluxRange="all", verbose=0, perSCkernel=False, scaleX=False, scaleY=False, scaleZ=True, edgeX=0, edgeY=0, edgeZ=0, method="1d2d", windowSpatial=20, windowSpectral=20, gridSpatial=0, gridSpectral=0, interpolation="none"):
 	# Define a few constants
 	FWHM_CONST    = 2.0 * math.sqrt(2.0 * math.log(2.0))   # Conversion between sigma and FWHM of Gaussian function
 	MAX_PIX_CONST = 1.0e+6                                 # Maximum number of pixels for noise calculation; sampling is set accordingly
@@ -67,7 +67,7 @@ def SCfinder_mem(cube, mask, header, t0, kernels=[[0, 0, 0, "b"],], threshold=3.
 			cube_smooth[np.isnan(cube)] = np.nan
 		
 		# Per-kernel noise normalisation (Time consuming!)
-		if scaleEachSCkernel:
+		if perSCkernel:
 			cube_smooth, noise_smooth = sigma_scale(cube_smooth, scaleX=scaleX, scaleY=scaleY, scaleZ=scaleZ, edgeX=edgeX, edgeY=edgeY, edgeZ=edgeZ, statistic=rmsMode, fluxRange=fluxRange, method=method, windowSpatial=windowSpatial, windowSpectral=windowSpectral, gridSpatial=gridSpatial, gridSpectral=gridSpectral, interpolation=interpolation)
 
 		# Calculate the RMS of the smoothed (possibly normalised) cube

--- a/sofia/readoptions.py
+++ b/sofia/readoptions.py
@@ -160,6 +160,7 @@ def allowedDataTypes():
 	        "scaleNoise.gridSpatial": "int", \
 	        "scaleNoise.gridSpectral": "int", \
 	        "scaleNoise.interpolation": "string", \
+	        "scaleNoise.scaleEachSCkernel": "bool", \
 	        "filterArtefacts.threshold": "float", \
 	        "filterArtefacts.dilation": "int", \
 	        "SCfind.threshold": "float", \
@@ -172,19 +173,6 @@ def allowedDataTypes():
 	        "SCfind.kernels": "array", \
 	        "SCfind.kernelUnit": "string", \
 	        "SCfind.verbose": "bool", \
-	        "SCfind.kernelNoiseScale": "bool", \
-	        "SCfind.method": "string", \
-	        "SCfind.edgeX": "int", \
-	        "SCfind.edgeY": "int", \
-	        "SCfind.edgeZ": "int", \
-	        "SCfind.scaleX": "bool", \
-	        "SCfind.scaleY": "bool", \
-	        "SCfind.scaleZ": "bool", \
-	        "SCfind.windowSpatial": "int", \
-	        "SCfind.windowSpectral": "int", \
-	        "SCfind.gridSpatial": "int", \
-	        "SCfind.gridSpectral": "int", \
-	        "SCfind.interpolation": "string", \
 	        "CNHI.pReq": "float", \
 	        "CNHI.qReq": "float", \
 	        "CNHI.minScale": "int", \

--- a/sofia/readoptions.py
+++ b/sofia/readoptions.py
@@ -160,7 +160,7 @@ def allowedDataTypes():
 	        "scaleNoise.gridSpatial": "int", \
 	        "scaleNoise.gridSpectral": "int", \
 	        "scaleNoise.interpolation": "string", \
-	        "scaleNoise.scaleEachSCkernel": "bool", \
+	        "scaleNoise.perSCkernel": "bool", \
 	        "filterArtefacts.threshold": "float", \
 	        "filterArtefacts.dilation": "int", \
 	        "SCfind.threshold": "float", \

--- a/sofia_pipeline.py
+++ b/sofia_pipeline.py
@@ -169,9 +169,9 @@ else:
 if Parameters["pipeline"]["trackMemory"]: print_memory_usage(t0)
 
 # Transfer scaleNoise arguments to SCfind for the purpose of scaling the noise after each smoothing iteration in the S+C finder
-for pp in "scaleEachSCkernel,method,edgeX,edgeY,edgeZ,scaleX,scaleY,scaleZ,windowSpatial,windowSpectral,gridSpatial,gridSpectral,interpolation".split(','):
+for pp in "perSCkernel,method,edgeX,edgeY,edgeZ,scaleX,scaleY,scaleZ,windowSpatial,windowSpectral,gridSpatial,gridSpectral,interpolation".split(','):
         Parameters["SCfind"].update({pp:Parameters["scaleNoise"][pp]})
-del(Parameters["scaleNoise"]["scaleEachSCkernel"])
+del(Parameters["scaleNoise"]["perSCkernel"])
 
 
 

--- a/sofia_pipeline.py
+++ b/sofia_pipeline.py
@@ -38,8 +38,6 @@ from sofia import CNHI
 from sofia import error as err
 from sofia import __version__ as sofia_version
 
-
-
 # --------------------------------
 # FUNCTION TO MONITOR MEMORY USAGE
 # --------------------------------
@@ -169,6 +167,12 @@ else:
 	outroot = outputDir + outroot
 
 if Parameters["pipeline"]["trackMemory"]: print_memory_usage(t0)
+
+# Transfer scaleNoise arguments to SCfind for the purpose of scaling the noise after each smoothing iteration in the S+C finder
+for pp in "scaleEachSCkernel,method,edgeX,edgeY,edgeZ,scaleX,scaleY,scaleZ,windowSpatial,windowSpectral,gridSpatial,gridSpectral,interpolation".split(','):
+        Parameters["SCfind"].update({pp:Parameters["scaleNoise"][pp]})
+del(Parameters["scaleNoise"]["scaleEachSCkernel"])
+
 
 
 # -------------------------------------------


### PR DESCRIPTION
This change simplifies the new option of scaling the noise within each smoothing+clipping iteration of SCfind. The original implementation of this new option (https://github.com/SoFiA-Admin/SoFiA/commit/4a7580fa3f44b1021f16716331a331ae3464ed76) requested all relevant noise scaling parameters to be set in the SCfind section of the SoFiA parameter file. However, all those parameters already exist in the scaleNoise section of the parameter file. Since there is no reason why these parameters should have different values in noiseScale and SCfind sections, they are now copied from noiseScale to SCfind. The only additional input parameter is then noiseScale.scaleEachSCkernel .